### PR TITLE
Improve access logic and welcome UI

### DIFF
--- a/backend/worker/src/auth.ts
+++ b/backend/worker/src/auth.ts
@@ -10,6 +10,7 @@ export async function registerHandler(c: Context) {
   if (!email || !password) return c.json({ error: 'Missing fields' }, 400);
 
   const db = getDB(c);
+  await DB.ensureUserSchema(db);
   const userCheck = await DB.getUserByEmail(db, email);
 
   if (userCheck) return c.json({ error: 'User already exists' }, 409);
@@ -28,6 +29,7 @@ export async function loginHandler(c: Context) {
   if (!email || !password) return c.json({ error: 'Missing fields' }, 400);
 
   const db = getDB(c);
+  await DB.ensureUserSchema(db);
   const user = await DB.getUserByEmail(db, email);
   if (!user) return c.json({ error: 'Invalid credentials' }, 401);
 

--- a/backend/worker/src/db.ts
+++ b/backend/worker/src/db.ts
@@ -6,6 +6,15 @@ export function getDB(c: Context): D1Database {
 }
 
 export const DB = {
+  async ensureUserSchema(db: D1Database) {
+    const info = await db.prepare('PRAGMA table_info(users)').all();
+    const hasPassword = info.results?.some((r: any) => r.name === 'password_hash');
+    if (!hasPassword) {
+      await db
+        .prepare('ALTER TABLE users ADD COLUMN password_hash TEXT')
+        .run();
+    }
+  },
   async getUserByEmail(db: D1Database, email: string) {
     const result = await db
       .prepare('SELECT * FROM users WHERE email = ?')

--- a/frontend/lib/screens/auth/welcome_screen.dart
+++ b/frontend/lib/screens/auth/welcome_screen.dart
@@ -8,50 +8,87 @@ class WelcomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Text(
-                'Добро пожаловать!',
-                style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              const Text(
-                'Платформа для обмена услугами и товарами.',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 16, color: Colors.grey),
-              ),
-              const SizedBox(height: 48),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 50),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Colors.blue, Colors.purple],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.groups, size: 100, color: Colors.white),
+                const SizedBox(height: 24),
+                const Text(
+                  'Asso pour Tous',
+                  style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const LoginScreen()),
-                  );
-                },
-                child: const Text('Войти'),
-              ),
-              const SizedBox(height: 16),
-              OutlinedButton(
-                style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 50),
+                const SizedBox(height: 12),
+                const Text(
+                  'Платформа для обмена услугами и товарами.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 18, color: Colors.white70),
                 ),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const RegisterScreen()),
-                  );
-                },
-                child: const Text('Зарегистрироваться'),
-              ),
-            ],
+                const SizedBox(height: 48),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: Colors.black,
+                      minimumSize: const Size(double.infinity, 50),
+                    ),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => const LoginScreen()),
+                      );
+                    },
+                    child: const Text('Войти'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton(
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: Colors.white),
+                      minimumSize: const Size(double.infinity, 50),
+                    ),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const RegisterScreen()),
+                      );
+                    },
+                    child: const Text(
+                      'Зарегистрироваться',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/about');
+                  },
+                  child: const Text(
+                    'Узнать больше',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/frontend/lib/screens/dashboard/dashboard_screen.dart
+++ b/frontend/lib/screens/dashboard/dashboard_screen.dart
@@ -43,8 +43,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
     }
 
     if (role != 'admin') {
-      return const Scaffold(
-        body: Center(child: Text('Access Denied: Admins only.')),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Dashboard')),
+        body: const Center(
+          child: Text('Добро пожаловать!'),
+        ),
       );
     }
 


### PR DESCRIPTION
## Summary
- show user-friendly dashboard instead of access denied message
- redesign welcome screen with gradient and extra actions
- automatically update user table schema on worker start

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870635e72a08323968983b731dc6a10