### PR TITLE
Fix dashboard history tile string quoting

### DIFF
--- a/frontend/lib/screens/dashboard/dashboard_screen.dart
+++ b/frontend/lib/screens/dashboard/dashboard_screen.dart
@@ -181,7 +181,7 @@ class _HistoryView extends StatelessWidget {
       itemBuilder: (context, index) {
         final tx = list[index];
         return ListTile(
-          title: Text('${tx['type']} \${tx['amount']}'),
+          title: Text('${tx['type']} \$${tx['amount']}'),
           subtitle: Text(tx['created_at'] ?? ''),
         );
       },


### PR DESCRIPTION
## Summary
- fix transaction history tile string interpolation quoting

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687077d9562083238d127056039f9819