### PR TITLE
Fix http dependencies and escape strings

### DIFF
--- a/frontend/lib/screens/ui_demo/ui_demo_screen.dart
+++ b/frontend/lib/screens/ui_demo/ui_demo_screen.dart
@@ -108,7 +108,7 @@ class _MessagesPage extends StatelessWidget {
                 leading: const CircleAvatar(
                     backgroundImage:
                         NetworkImage('https://via.placeholder.com/50')),
-                title: Text('User \\${i}'),
+                title: Text('User $i'),
                 subtitle: const Text('Last message'),
                 onTap: () {},
               ),
@@ -172,7 +172,7 @@ class _MyListingsPage extends StatelessWidget {
                 3,
                 (i) => Card(
                   child: ListTile(
-                    title: Text('My project \\${i}'),
+                    title: Text('My project $i'),
                     subtitle: const Text('Service'),
                     trailing: Row(
                       mainAxisSize: MainAxisSize.min,
@@ -242,7 +242,7 @@ class _ProductCard extends StatelessWidget {
                   Text('Product name',
                       style: TextStyle(fontWeight: FontWeight.bold)),
                   Text('Category'),
-                  Text('\\$42'),
+                  Text('\$42'),
                 ],
               ),
             ),

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   url_strategy: any
   shared_preferences: ^2.2.0
   crypto: ^3.0.3
+  http: ^1.1.0
   
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add missing `http` package to Flutter dependencies
- fix string escapes in UI demo screen to eliminate build errors

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713a1746848323bd4e43b6c013fb90