### PR TITLE
UI updates and navigation wiring

### DIFF
--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -194,6 +194,14 @@ abstract class AppLocalizations {
 
   String get recentAnnouncements;
 
+  String get featuredProjects;
+
+  String get categories;
+
+  String get contact;
+
+  String get exploreNow;
+
   String get postProject;
 
   String get projectName;

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -77,6 +77,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recentAnnouncements => 'Recent Announcements';
 
   @override
+  String get featuredProjects => 'Featured Projects';
+
+  @override
+  String get categories => 'Categories';
+
+  @override
+  String get contact => 'Contact';
+
+  @override
+  String get exploreNow => 'Explore Now';
+
+  @override
   String get postProject => 'Post project';
 
   @override

--- a/frontend/lib/l10n/app_localizations_fr.dart
+++ b/frontend/lib/l10n/app_localizations_fr.dart
@@ -77,6 +77,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recentAnnouncements => 'Annonces récentes';
 
   @override
+  String get featuredProjects => 'Projets mis en avant';
+
+  @override
+  String get categories => 'Catégories';
+
+  @override
+  String get contact => 'Contact';
+
+  @override
+  String get exploreNow => 'Découvrir';
+
+  @override
   String get postProject => 'Publier un projet';
 
   @override

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -4,12 +4,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'screens/auth/login_screen.dart';
+import 'screens/auth/register_screen.dart';
 import 'screens/ui_demo/ui_demo_screen.dart';
 import 'screens/landing/landing_screen.dart';
+import 'screens/about_screen.dart';
+import 'screens/catalog_screen.dart';
+import 'screens/contact_screen.dart';
+import 'screens/categories_screen.dart';
 import 'services/jwt_service.dart';
 import 'router.dart';
 import 'l10n/app_localizations.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -46,10 +51,7 @@ class _MyAppState extends State<MyApp> {
         return MaterialApp(
           debugShowCheckedModeBanner: false,
           title: 'Platform',
-          theme: ThemeData(
-            useMaterial3: true,
-            textTheme: GoogleFonts.interTextTheme(),
-          ),
+          theme: lightTheme,
           locale: _locale,
           supportedLocales: const [
             Locale('en'),
@@ -61,6 +63,15 @@ class _MyAppState extends State<MyApp> {
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
           ],
+          routes: {
+            '/login': (_) => const LoginScreen(),
+            '/register': (_) => const RegisterScreen(),
+            '/about': (_) => const AboutScreen(),
+            '/contact': (_) => const ContactScreen(),
+            '/catalog': (_) => const CatalogScreen(),
+            '/categories': (_) => const CategoriesScreen(),
+            '/dashboard': (_) => const UiDemoScreen(),
+          },
           home: userId != null
               ? Scaffold(
                   body: Column(

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -6,6 +6,7 @@ import '../dashboard/dashboard_screen.dart';
 import 'register_screen.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../../l10n/app_localizations.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -52,6 +53,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
       body: Center(
         child: Container(
@@ -60,25 +62,22 @@ class _LoginScreenState extends State<LoginScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                'Вход в платформу',
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
+              Text(t.login, style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 20),
               TextField(
                 controller: _emailController,
-                decoration: const InputDecoration(
-                  labelText: 'Email',
-                  border: OutlineInputBorder(),
+                decoration: InputDecoration(
+                  labelText: t.email,
+                  border: const OutlineInputBorder(),
                 ),
               ),
               const SizedBox(height: 16),
               TextField(
                 controller: _passwordController,
                 obscureText: true,
-                decoration: const InputDecoration(
-                  labelText: 'Пароль',
-                  border: OutlineInputBorder(),
+                decoration: InputDecoration(
+                  labelText: t.password,
+                  border: const OutlineInputBorder(),
                 ),
               ),
               if (_error != null) ...[
@@ -90,7 +89,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: _login,
-                  child: const Text('Войти'),
+                  child: Text(t.logIn),
                 ),
               ),
               TextButton(
@@ -100,7 +99,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     MaterialPageRoute(builder: (_) => const RegisterScreen()),
                   );
                 },
-                child: const Text('Регистрация'),
+                child: Text(t.signUp),
               ),
             ],
           ),

--- a/frontend/lib/screens/auth/register_screen.dart
+++ b/frontend/lib/screens/auth/register_screen.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../dashboard/dashboard_screen.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../../l10n/app_localizations.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -55,21 +56,22 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: const Text('Регистрация')),
+      appBar: AppBar(title: Text(t.signUp)),
       body: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
           children: [
             TextField(
               controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              decoration: InputDecoration(labelText: t.email),
             ),
             const SizedBox(height: 16),
             TextField(
               controller: _passwordController,
               obscureText: true,
-              decoration: const InputDecoration(labelText: 'Пароль'),
+              decoration: InputDecoration(labelText: t.password),
             ),
             const SizedBox(height: 24),
             if (_errorMessage.isNotEmpty)
@@ -79,9 +81,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: _isLoading ? null : _register,
-                child: _isLoading
-                    ? const CircularProgressIndicator()
-                    : const Text('Зарегистрироваться'),
+                child:
+                    _isLoading ? const CircularProgressIndicator() : Text(t.signUp),
               ),
             ),
           ],

--- a/frontend/lib/screens/catalog_screen.dart
+++ b/frontend/lib/screens/catalog_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
+
+class CatalogScreen extends StatelessWidget {
+  const CatalogScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(t.featuredProducts)),
+      body: const Center(child: Text('Catalog page')),
+    );
+  }
+}

--- a/frontend/lib/screens/categories_screen.dart
+++ b/frontend/lib/screens/categories_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
+
+class CategoriesScreen extends StatelessWidget {
+  const CategoriesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(t.categories)),
+      body: const Center(child: Text('Categories page')),
+    );
+  }
+}

--- a/frontend/lib/screens/contact_screen.dart
+++ b/frontend/lib/screens/contact_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../l10n/app_localizations.dart';
+
+class ContactScreen extends StatelessWidget {
+  const ContactScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(t.contact)),
+      body: const Center(child: Text('Contact page')),
+    );
+  }
+}

--- a/frontend/lib/screens/landing/landing_screen.dart
+++ b/frontend/lib/screens/landing/landing_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import '../../l10n/app_localizations.dart';
 
 class LandingScreen extends StatefulWidget {
   final Locale locale;
@@ -29,6 +30,7 @@ class _LandingScreenState extends State<LandingScreen> {
             _HeroSection(controller: _controller),
             const _AdvantagesSection(),
             const _CategoriesSection(),
+            const _FeaturedProjectsSection(),
             _Footer(
               locale: widget.locale,
               onLocaleChange: widget.onLocaleChange,
@@ -47,12 +49,13 @@ class _Header extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     final isDesktop = MediaQuery.of(context).size.width > 800;
     final items = [
-      _NavItem('Home'),
-      _NavItem('Categories'),
-      _NavItem('About'),
-      _NavItem('Contact'),
+      _NavItem(t.home, '/'),
+      _NavItem(t.categories, '/categories'),
+      _NavItem('About', '/about'),
+      _NavItem(t.contact, '/contact'),
     ];
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
@@ -69,16 +72,16 @@ class _Header extends StatelessWidget {
             const SizedBox.shrink(),
           const SizedBox(width: 24),
           TextButton(
-            onPressed: () {},
-            child: const Text('Sign in'),
+            onPressed: () => Navigator.pushNamed(context, '/login'),
+            child: Text(t.login),
           ),
           const SizedBox(width: 12),
           ElevatedButton(
-            onPressed: () {},
+            onPressed: () => Navigator.pushNamed(context, '/register'),
             style: ElevatedButton.styleFrom(
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
             ),
-            child: const Text('Join now'),
+            child: Text(t.signUp),
           ),
           const SizedBox(width: 24),
           DropdownButton<Locale>(
@@ -98,7 +101,8 @@ class _Header extends StatelessWidget {
 
 class _NavItem extends StatelessWidget {
   final String title;
-  const _NavItem(this.title);
+  final String route;
+  const _NavItem(this.title, this.route);
 
   @override
   Widget build(BuildContext context) {
@@ -107,7 +111,7 @@ class _NavItem extends StatelessWidget {
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: TextButton(
-          onPressed: () {},
+          onPressed: () => Navigator.pushNamed(context, route),
           child: Text(title),
         ),
       ),
@@ -165,7 +169,7 @@ class _HeroSection extends StatelessWidget {
                 ),
                 const SizedBox(height: 32),
                 ElevatedButton(
-                  onPressed: () {},
+                  onPressed: () => Navigator.pushNamed(context, '/catalog'),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 32, vertical: 16),
@@ -173,7 +177,7 @@ class _HeroSection extends StatelessWidget {
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
-                  child: const Text('Explore Now'),
+                  child: Text(AppLocalizations.of(context)!.exploreNow),
                 ),
               ],
             ),
@@ -271,9 +275,9 @@ class _Cat extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: InkWell(
-        onTap: () {},
+        onTap: () => Navigator.pushNamed(context, '/catalog'),
         hoverColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
         child: Center(
           child: Column(
@@ -285,6 +289,74 @@ class _Cat extends StatelessWidget {
               Text(label, style: GoogleFonts.inter()),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeaturedProjectsSection extends StatelessWidget {
+  const _FeaturedProjectsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(t.featuredProjects,
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 16),
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              mainAxisSpacing: 24,
+              crossAxisSpacing: 24,
+              childAspectRatio: 3 / 4,
+            ),
+            itemCount: 3,
+            itemBuilder: (_, __) => const _ProjectCard(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProjectCard extends StatelessWidget {
+  const _ProjectCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {},
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Ink.image(
+                image: NetworkImage('https://via.placeholder.com/200'),
+                fit: BoxFit.cover,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: const [
+                  Text('Project name',
+                      style: TextStyle(fontWeight: FontWeight.bold)),
+                  Text('Category'),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/frontend/lib/theme.dart
+++ b/frontend/lib/theme.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+final ThemeData lightTheme = ThemeData(
+  useMaterial3: true,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: const Color(0xFF6750A4),
+    brightness: Brightness.light,
+  ),
+  textTheme: GoogleFonts.interTextTheme(),
+);
+


### PR DESCRIPTION
## Summary
- add shared `lightTheme`
- hook up named routes in `main.dart`
- translate login and register screens
- create catalog, categories and contact screens
- improve landing page navigation and add featured projects section

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687147caa6d8832397118a5f20911fed