### PR TITLE
Improve landing and add icons

### DIFF
--- a/frontend/lib/screens/about_screen.dart
+++ b/frontend/lib/screens/about_screen.dart
@@ -3,11 +3,31 @@ import '../../l10n/app_localizations.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return Scaffold(
-      body: Center(child: Text(t.aboutTitle, style: const TextStyle(fontSize: 24))),
+      appBar: AppBar(title: Text(t.aboutTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Icon(Icons.info_outline, size: 80),
+            SizedBox(height: 16),
+            Text(
+              'Asso pour Tous is a non-profit platform that helps the community exchange goods and services.',
+              style: TextStyle(fontSize: 18),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Our mission is to connect people, encourage volunteering and empower local initiatives.',
+              style: TextStyle(fontSize: 18),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -87,9 +87,10 @@ class _LoginScreenState extends State<LoginScreen> {
               const SizedBox(height: 20),
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
+                child: ElevatedButton.icon(
                   onPressed: _login,
-                  child: Text(t.logIn),
+                  icon: const Icon(Icons.login),
+                  label: Text(t.logIn),
                 ),
               ),
               TextButton(

--- a/frontend/lib/screens/auth/register_screen.dart
+++ b/frontend/lib/screens/auth/register_screen.dart
@@ -79,10 +79,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
             const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
-              child: ElevatedButton(
+              child: ElevatedButton.icon(
                 onPressed: _isLoading ? null : _register,
-                child:
-                    _isLoading ? const CircularProgressIndicator() : Text(t.signUp),
+                icon: const Icon(Icons.app_registration),
+                label: _isLoading
+                    ? const CircularProgressIndicator()
+                    : Text(t.signUp),
               ),
             ),
           ],

--- a/frontend/lib/screens/auth/welcome_screen.dart
+++ b/frontend/lib/screens/auth/welcome_screen.dart
@@ -41,7 +41,7 @@ class WelcomeScreen extends StatelessWidget {
                 const SizedBox(height: 48),
                 SizedBox(
                   width: double.infinity,
-                  child: ElevatedButton(
+                  child: ElevatedButton.icon(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.white,
                       foregroundColor: Colors.black,
@@ -53,13 +53,14 @@ class WelcomeScreen extends StatelessWidget {
                         MaterialPageRoute(builder: (_) => const LoginScreen()),
                       );
                     },
-                    child: const Text('Войти'),
+                    icon: const Icon(Icons.login),
+                    label: const Text('Войти'),
                   ),
                 ),
                 const SizedBox(height: 16),
                 SizedBox(
                   width: double.infinity,
-                  child: OutlinedButton(
+                  child: OutlinedButton.icon(
                     style: OutlinedButton.styleFrom(
                       side: const BorderSide(color: Colors.white),
                       minimumSize: const Size(double.infinity, 50),
@@ -71,7 +72,8 @@ class WelcomeScreen extends StatelessWidget {
                             builder: (_) => const RegisterScreen()),
                       );
                     },
-                    child: const Text(
+                    icon: const Icon(Icons.app_registration, color: Colors.white),
+                    label: const Text(
                       'Зарегистрироваться',
                       style: TextStyle(color: Colors.white),
                     ),
@@ -82,9 +84,16 @@ class WelcomeScreen extends StatelessWidget {
                   onPressed: () {
                     Navigator.pushNamed(context, '/about');
                   },
-                  child: const Text(
-                    'Узнать больше',
-                    style: TextStyle(color: Colors.white),
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.info, color: Colors.white),
+                      SizedBox(width: 8),
+                      Text(
+                        'Узнать больше',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                    ],
                   ),
                 ),
               ],

--- a/frontend/lib/screens/catalog_screen.dart
+++ b/frontend/lib/screens/catalog_screen.dart
@@ -9,7 +9,36 @@ class CatalogScreen extends StatelessWidget {
     final t = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: Text(t.featuredProducts)),
-      body: const Center(child: Text('Catalog page')),
+      body: GridView.builder(
+        padding: const EdgeInsets.all(24),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          mainAxisSpacing: 16,
+          crossAxisSpacing: 16,
+          childAspectRatio: 3 / 4,
+        ),
+        itemCount: 4,
+        itemBuilder: (_, i) => Card(
+          child: InkWell(
+            onTap: () => Navigator.pushNamed(context, '/about'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Ink.image(
+                    image: NetworkImage('https://via.placeholder.com/200?text=Item'+i.toString()),
+                    fit: BoxFit.cover,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text('Item '+i.toString()),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/screens/categories_screen.dart
+++ b/frontend/lib/screens/categories_screen.dart
@@ -9,7 +9,15 @@ class CategoriesScreen extends StatelessWidget {
     final t = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: Text(t.categories)),
-      body: const Center(child: Text('Categories page')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: const [
+          ListTile(leading: Icon(Icons.shopping_cart), title: Text('Buy items')),
+          ListTile(leading: Icon(Icons.sell), title: Text('Sell items')),
+          ListTile(leading: Icon(Icons.design_services), title: Text('Services')),
+          ListTile(leading: Icon(Icons.volunteer_activism), title: Text('Volunteer')),
+        ],
+      ),
     );
   }
 }

--- a/frontend/lib/screens/contact_screen.dart
+++ b/frontend/lib/screens/contact_screen.dart
@@ -9,7 +9,19 @@ class ContactScreen extends StatelessWidget {
     final t = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: Text(t.contact)),
-      body: const Center(child: Text('Contact page')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Icon(Icons.mail_outline, size: 80),
+            SizedBox(height: 16),
+            Text('Email: contact@assopourtous.com', style: TextStyle(fontSize: 18)),
+            SizedBox(height: 8),
+            Text('Phone: +33 123 456 789', style: TextStyle(fontSize: 18)),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/screens/landing/landing_screen.dart
+++ b/frontend/lib/screens/landing/landing_screen.dart
@@ -71,17 +71,19 @@ class _Header extends StatelessWidget {
           else
             const SizedBox.shrink(),
           const SizedBox(width: 24),
-          TextButton(
+          TextButton.icon(
             onPressed: () => Navigator.pushNamed(context, '/login'),
-            child: Text(t.login),
+            icon: const Icon(Icons.login),
+            label: Text(t.login),
           ),
           const SizedBox(width: 12),
-          ElevatedButton(
+          ElevatedButton.icon(
             onPressed: () => Navigator.pushNamed(context, '/register'),
             style: ElevatedButton.styleFrom(
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
             ),
-            child: Text(t.signUp),
+            icon: const Icon(Icons.app_registration),
+            label: Text(t.signUp),
           ),
           const SizedBox(width: 24),
           DropdownButton<Locale>(
@@ -168,7 +170,7 @@ class _HeroSection extends StatelessWidget {
                   style: GoogleFonts.inter(fontSize: 20, color: Colors.white70),
                 ),
                 const SizedBox(height: 32),
-                ElevatedButton(
+                ElevatedButton.icon(
                   onPressed: () => Navigator.pushNamed(context, '/catalog'),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
@@ -177,7 +179,8 @@ class _HeroSection extends StatelessWidget {
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
-                  child: Text(AppLocalizations.of(context)!.exploreNow),
+                  icon: const Icon(Icons.explore),
+                  label: Text(AppLocalizations.of(context)!.exploreNow),
                 ),
               ],
             ),
@@ -335,7 +338,7 @@ class _ProjectCard extends StatelessWidget {
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () {},
+        onTap: () => Navigator.pushNamed(context, '/about'),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -368,6 +371,12 @@ class _Footer extends StatelessWidget {
   final void Function(Locale) onLocaleChange;
   const _Footer({required this.locale, required this.onLocaleChange});
 
+  void _showSocial(BuildContext context, String name) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$name link tapped')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -383,13 +392,16 @@ class _Footer extends StatelessWidget {
           const SizedBox(height: 12),
           Row(
             children: [
-              IconButton(onPressed: () {}, icon: const Icon(Icons.facebook)),
               IconButton(
-                onPressed: () {},
+                onPressed: () => _showSocial(context, 'Facebook'),
+                icon: const Icon(Icons.facebook),
+              ),
+              IconButton(
+                onPressed: () => _showSocial(context, 'Twitter'),
                 icon: const FaIcon(FontAwesomeIcons.twitter),
               ),
               IconButton(
-                onPressed: () {},
+                onPressed: () => _showSocial(context, 'Instagram'),
                 icon: const FaIcon(FontAwesomeIcons.instagram),
               ),
               const Spacer(),

--- a/frontend/lib/screens/ui_demo/ui_demo_screen.dart
+++ b/frontend/lib/screens/ui_demo/ui_demo_screen.dart
@@ -110,7 +110,11 @@ class _MessagesPage extends StatelessWidget {
                         NetworkImage('https://via.placeholder.com/50')),
                 title: Text('User $i'),
                 subtitle: const Text('Last message'),
-                onTap: () {},
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Open chat with User $i')),
+                  );
+                },
               ),
             ),
           ),
@@ -131,7 +135,11 @@ class _MessagesPage extends StatelessWidget {
                     hintText: 'Message',
                     suffixIcon: IconButton(
                       icon: const Icon(Icons.send),
-                      onPressed: () {},
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Message sent')), 
+                        );
+                      },
                     ),
                     border: const OutlineInputBorder(),
                   ),
@@ -179,11 +187,19 @@ class _MyListingsPage extends StatelessWidget {
                       children: [
                         IconButton(
                           icon: const Icon(Icons.edit),
-                          onPressed: () {},
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Edit project $i')),
+                            );
+                          },
                         ),
                         IconButton(
                           icon: const Icon(Icons.delete),
-                          onPressed: () {},
+                          onPressed: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Delete project $i')),
+                            );
+                          },
                         ),
                       ],
                     ),
@@ -224,7 +240,7 @@ class _ProductCard extends StatelessWidget {
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () {},
+        onTap: () => Navigator.pushNamed(context, '/catalog'),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -260,10 +276,11 @@ class _AnnouncementCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
-      child: const ListTile(
-        leading: Icon(Icons.announcement_outlined),
-        title: Text('Announcement title'),
-        subtitle: Text('Some description goes here.'),
+      child: ListTile(
+        leading: const Icon(Icons.announcement_outlined),
+        title: const Text('Announcement title'),
+        subtitle: const Text('Some description goes here.'),
+        onTap: () => Navigator.pushNamed(context, '/about'),
       ),
     );
   }
@@ -278,7 +295,7 @@ class _ActionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: InkWell(
-        onTap: () {},
+        onTap: () => Navigator.pushNamed(context, '/catalog'),
         hoverColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
         child: Center(
           child: Column(

--- a/frontend/lib/widgets/ui_demo_scaffold.dart
+++ b/frontend/lib/widgets/ui_demo_scaffold.dart
@@ -36,7 +36,11 @@ class UiDemoScaffold extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.notifications_outlined),
-            onPressed: () {},
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Notifications')),
+              );
+            },
           ),
           const CircleAvatar(
             radius: 16,


### PR DESCRIPTION
## Summary
- add icons and actions for login/register buttons
- create simple about, catalog, categories and contact pages
- link project cards and action cards to routes
- add small UX improvements with snack bars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68714f54ea9483238741b709b347214a