### PR TITLE
Fix type errors for web build

### DIFF
--- a/frontend/lib/screens/catalog_screen.dart
+++ b/frontend/lib/screens/catalog_screen.dart
@@ -50,7 +50,7 @@ class CatalogScreen extends StatelessWidget {
               children: [
                 Expanded(
                   child: Ink.image(
-                    image: NetworkImage(item['image']!),
+                    image: NetworkImage(item['image'] as String),
                     fit: BoxFit.cover,
                   ),
                 ),
@@ -59,7 +59,7 @@ class CatalogScreen extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(item['name']!,
+                      Text(item['name'] as String,
                           style: const TextStyle(fontWeight: FontWeight.bold)),
                       Text('\$${item['price']}'),
                       const SizedBox(height: 4),

--- a/frontend/lib/screens/dashboard/announcements_screen.dart
+++ b/frontend/lib/screens/dashboard/announcements_screen.dart
@@ -18,8 +18,8 @@ class AnnouncementsScreen extends StatelessWidget {
         final a = announcements[i];
         return ListTile(
           leading: const Icon(Icons.campaign_outlined),
-          title: Text(a['title']!),
-          subtitle: Text(a['description']!),
+          title: Text(a['title'] as String),
+          subtitle: Text(a['description'] as String),
           onTap: () {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Отклик отправлен')),

--- a/frontend/lib/screens/dashboard/market_screen.dart
+++ b/frontend/lib/screens/dashboard/market_screen.dart
@@ -45,7 +45,7 @@ class MarketScreen extends StatelessWidget {
             children: [
               Expanded(
                 child: Ink.image(
-                  image: NetworkImage(item['image']!),
+                  image: NetworkImage(item['image'] as String),
                   fit: BoxFit.cover,
                 ),
               ),
@@ -54,7 +54,7 @@ class MarketScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(item['name']!,
+                    Text(item['name'] as String,
                         style: const TextStyle(fontWeight: FontWeight.bold)),
                     Text('\$${item['price']}'),
                     const SizedBox(height: 8),

--- a/frontend/lib/screens/dashboard/projects_screen.dart
+++ b/frontend/lib/screens/dashboard/projects_screen.dart
@@ -26,8 +26,8 @@ class ProjectsScreen extends StatelessWidget {
         for (final p in projects)
           Card(
             child: ListTile(
-              title: Text(p['name']!),
-              subtitle: Text(p['category']!),
+              title: Text(p['name'] as String),
+              subtitle: Text(p['category'] as String),
             ),
           )
       ],


### PR DESCRIPTION
## Summary
- fix type issues in dashboard screens
- cast map values to Strings when used in widgets

## Testing
- `dart format frontend/lib/screens/catalog_screen.dart frontend/lib/screens/dashboard/market_screen.dart frontend/lib/screens/dashboard/projects_screen.dart frontend/lib/screens/dashboard/announcements_screen.dart` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687158539140832381c0059962230e47